### PR TITLE
update deployconfigFiles so it doesn't kill robot code

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -50,6 +50,7 @@ deploy {
 
                 // Just the (static) config files
                 configFiles(getArtifactTypeClass('FileTreeArtifact')) {
+                    setDeployStage(it, 'BeforeProgramKill')
                     files = project.fileTree('src/main/deploy/configs')
                     directory = '/home/lvuser/deploy/configs'
                 }


### PR DESCRIPTION
specify that the deployconfigFiles task should occur at a stage before GradleRIO kills robot code.
recommendation from one of the GradleRIO devs after asking about this on Chief Delphi.
