### PR TITLE
switch to java lite runtime for protobufs

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -93,7 +93,7 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 
     // our files
-    implementation "com.google.protobuf:protobuf-java:${protobufVersion}"
+    implementation "com.google.protobuf:protobuf-javalite:${protobufVersion}"
 
     implementation files('deps/commons-math3-3.6.1.jar')
     implementation files('deps/gral-core-0.11.jar')
@@ -153,6 +153,24 @@ protobuf {
   protoc {
     // Download from repositories
     artifact = "com.google.protobuf:protoc:${protobufVersion}"
+  }
+
+
+  plugins {
+    javalite {
+      // The codegen for lite comes as a separate artifact
+      artifact = 'com.google.protobuf:protoc-gen-javalite:${protobufVersion}'
+    }
+  }
+
+  generateProtoTasks {
+    all().configureEach { task ->
+      task.builtins {
+        java {
+          option "lite"
+        }
+      }
+    }
   }
 }
 

--- a/src/main/java/com/team766/logging/Logger.java
+++ b/src/main/java/com/team766/logging/Logger.java
@@ -100,8 +100,9 @@ public class Logger {
 		}
 		entry.setMessageStr(format);
 		for (Object arg : args) {
-			SerializationUtils.valueToProto(arg, entry.addArgBuilder());
-		}
+			var logValue = LogValue.newBuilder();
+			SerializationUtils.valueToProto(arg, logValue);
+			entry.addArg(logValue.build());		}
 		if (m_logWriter != null) {
 			m_logWriter.logStoredFormat(entry);
 		}

--- a/src/main/java/com/team766/logging/Logger.java
+++ b/src/main/java/com/team766/logging/Logger.java
@@ -102,7 +102,8 @@ public class Logger {
 		for (Object arg : args) {
 			var logValue = LogValue.newBuilder();
 			SerializationUtils.valueToProto(arg, logValue);
-			entry.addArg(logValue.build());		}
+			entry.addArg(logValue.build());
+		}
 		if (m_logWriter != null) {
 			m_logWriter.logStoredFormat(entry);
 		}


### PR DESCRIPTION
## Description

Switch from java to javalite protobufs.  Java protobufs are known to be memory intensive.  Java lite protobufs provide a subset of the functionality for the same speed but lower memory footprint; they are the recommended option to use in lower-memory environments like Android.

We have been seeing memory issues in some instances, especially on a RoboRio (vs RoboRio 2), so taking this step to see if that helps reduce the memory footprint of logging.  We'll likely. need to do some more testing (ideally once we can also get HPROF dumps from the robot and analyze the overall object memory usage).

## How Has This Been Tested?

This has *not* yet been tested on a robot.  This illustrates what we'd need to do to switch to javalite but needs to be tested on a robot.