### PR TITLE
add javadoc target to build

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -102,6 +102,10 @@ dependencies {
     implementation files('deps/json-20190722.jar')
 }
 
+javadoc {
+  source = sourceSets.main.allJava
+}
+
 test {
     useJUnitPlatform()
     systemProperty 'junit.jupiter.extensions.autodetection.enabled', 'true'

--- a/src/main/java/com/team766/controllers/PIDController.java
+++ b/src/main/java/com/team766/controllers/PIDController.java
@@ -209,7 +209,6 @@ public class PIDController {
 	/** Same as calculate() except that it prints debugging information
 	 * 
 	 * @param cur_input The current input to be plugged into the PID controller
-	 * @param smart True if you want the output to be dynamically adjusted to the motor controller
 	 */
 	public void calculateDebug(double cur_input) {
 		print = true;


### PR DESCRIPTION
NOTE: compiling javadocs emits many warnings due to missing @param's, @return's, etc.  we'll fix those separately from this PR.

## Description

Adds a javadoc target to our builds.  This is the first step in a process to generate and host javadocs on github.
This will be even more important to do for Maroon Framework APIs.


## How Has This Been Tested?

Generate javadocs via ./gradlew javadoc
Fixed one error from a stale @param