### PR TITLE
Print useful message when reading motor config fails.

### DIFF
--- a/src/main/java/com/team766/hal/RobotProvider.java
+++ b/src/main/java/com/team766/hal/RobotProvider.java
@@ -2,6 +2,8 @@ package com.team766.hal;
 
 import java.util.Arrays;
 import java.util.HashMap;
+import java.io.StringWriter;
+import java.io.PrintWriter;
 
 import com.team766.config.ConfigFileReader;
 import com.team766.controllers.TimeProviderI;
@@ -116,7 +118,11 @@ public abstract class RobotProvider {
 			}
 			return motor;
 		} catch (IllegalArgumentException ex) {
-			Logger.get(Category.CONFIGURATION).logData(Severity.ERROR, "Motor %s not found in config file, using mock motor instead", configName);
+			StringWriter exsw = new StringWriter();
+			ex.printStackTrace(new PrintWriter(exsw));
+			Logger.get(Category.CONFIGURATION).logData(Severity.ERROR, 
+			  "Error getting configuration for motor %s from config file, using mock motor instead.\nDetailed error: %s", 
+			  configName, exsw.toString());
 			return new LocalMotorController(configName, new MockMotorController(0), sensor);
 		}
 	}


### PR DESCRIPTION
## Description

Previously any error in the motor configuration would result in a log message telling you that the motor was not present in the config file. This was rather baffling as it showed up even when the motor was present, albeit misconfigured. Now a messages indicating that an error is present in the motor's configuration is printed, along with the full exception, which usually contains useful information about the sub-field that is responsible, and worst case the stack trace that gets you to the line that is unhappy.

## How Has This Been Tested?

- [x] On-robot bench testing: I misconfigured my robot, and observed the more detailed log message.
