### PR TITLE
Added a mode to view all log messages in the web UI.

### DIFF
--- a/src/main/java/com/team766/web/LogViewer.java
+++ b/src/main/java/com/team766/web/LogViewer.java
@@ -14,6 +14,7 @@ import com.team766.logging.Severity;
 public class LogViewer implements WebServer.Handler {
 	private static final String ENDPOINT = "/logs";
 	private static final String ALL_ERRORS_NAME = "All Errors";
+	private static final String ALL_MESSAGES_NAME = "All Messages";
 
 	private static final SimpleDateFormat timeFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
 
@@ -37,7 +38,9 @@ public class LogViewer implements WebServer.Handler {
 				categoryName,
 				Stream.concat(
 					Stream.of(ALL_ERRORS_NAME),
-					Arrays.stream(Category.values()).map(Category::name)
+					Stream.concat(
+						Stream.of(ALL_MESSAGES_NAME),
+						Arrays.stream(Category.values()).map(Category::name))
 				).toArray(String[]::new)),
 			"<input type=\"submit\" value=\"View\">",
 			"</p></form>",
@@ -86,6 +89,14 @@ public class LogViewer implements WebServer.Handler {
 				::iterator);
 	}
 
+	static String makeAllMessagesPage() {
+		return makePage(
+			ALL_MESSAGES_NAME,
+			Arrays.stream(Category.values())
+				.flatMap(category -> Logger.get(category).recentEntries().stream())
+				::iterator);
+	}
+
 	@Override
 	public String endpoint() {
 		return ENDPOINT;
@@ -96,6 +107,8 @@ public class LogViewer implements WebServer.Handler {
 		String categoryName = (String)params.get("category");
 		if (categoryName == null || categoryName.equals(ALL_ERRORS_NAME)) {
 			return makeAllErrorsPage();
+		} else if (categoryName.equals(ALL_MESSAGES_NAME)) {
+			return makeAllMessagesPage();
 		} else {
 			Category category = Enum.valueOf(Category.class, categoryName);
 			return makePage(category.name(), Logger.get(category).recentEntries());

--- a/src/main/java/com/team766/web/LogViewer.java
+++ b/src/main/java/com/team766/web/LogViewer.java
@@ -37,10 +37,8 @@ public class LogViewer implements WebServer.Handler {
 				"category",
 				categoryName,
 				Stream.concat(
-					Stream.of(ALL_ERRORS_NAME),
-					Stream.concat(
-						Stream.of(ALL_MESSAGES_NAME),
-						Arrays.stream(Category.values()).map(Category::name))
+					Stream.of(ALL_ERRORS_NAME, ALL_MESSAGES_NAME),
+					Arrays.stream(Category.values()).map(Category::name)
 				).toArray(String[]::new)),
 			"<input type=\"submit\" value=\"View\">",
 			"</p></form>",


### PR DESCRIPTION
## Description

There is now an All Messages, similar to the All Errors option when viewing the logs. This avoids digging around through the various components if you want to see if there is any hint of what is going wrong.

## How Has This Been Tested?

- On-robot bench testing: Connected to the logging interface, selected All Messages, and confirmed that all my messages seemed to be showing up there.
