### PR TITLE
fix swerve

### DIFF
--- a/src/main/java/com/team766/robot/OI.java
+++ b/src/main/java/com/team766/robot/OI.java
@@ -91,11 +91,9 @@ public class OI extends Procedure {
 				}
 			} */
 
-			if(joystick1.getButton(2)){
-				Robot.drive.setGyro(0);
-			}else{
-				Robot.drive.setGyro(Robot.gyro.getGyroYaw());
-			}		
+			
+				Robot.drive.setGyro(-Robot.gyro.getGyroYaw());
+				
 
 			if(Math.abs(joystick1.getAxis(InputConstants.AXIS_FORWARD_BACKWARD)) > 0.05){
 				RightJoystick_Y = joystick1.getAxis(InputConstants.AXIS_FORWARD_BACKWARD);
@@ -178,8 +176,8 @@ public class OI extends Procedure {
 
 			if (isCross)  {
 				context.startAsync(new setCross());
-			/*} else if (joystick0.getButton(3)) {
-				Robot.drive.swerveDrive(0, 0.2, 0);*/
+			} else if (joystick0.getButton(3)) {
+				Robot.drive.swerveDrive(0, 0.2, 0);
 			} else if(Math.abs(LeftJoystick_X)+
 			Math.abs(LeftJoystick_Y) +  Math.abs(RightJoystick_X) > 0) {
 				Robot.drive.swerveDrive( 

--- a/src/main/java/com/team766/robot/mechanisms/Drive.java
+++ b/src/main/java/com/team766/robot/mechanisms/Drive.java
@@ -11,6 +11,7 @@ import com.team766.library.RateLimiter;
 import com.team766.library.ValueProvider;
 import com.team766.logging.Category;
 import com.team766.simulator.ProgramInterface.RobotMode;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import com.team766.config.ConfigFileReader;
 import com.team766.framework.Mechanism;
 import com.ctre.phoenix.motorcontrol.FeedbackDevice;
@@ -125,6 +126,10 @@ public class Drive extends Mechanism {
 		log("MotorList Length: " + motorList.length);
 		log("CANCoderList Length: " + CANCoderList.length);
 		swerveOdometry = new Odometry(motorList, CANCoderList, wheelPositions, OdometryInputConstants.WHEEL_CIRCUMFERENCE, OdometryInputConstants.GEAR_RATIO, OdometryInputConstants.ENCODER_TO_REVOLUTION_CONSTANT, OdometryInputConstants.RATE_LIMITER_TIME);
+		setFrontRightEncoders();
+		setFrontLeftEncoders();
+		setBackRightEncoders();
+		setBackLeftEncoders();
 	}
 
 	// A set of simple functions for the sake of adding vectors
@@ -495,8 +500,11 @@ public class Drive extends Mechanism {
 	 * This method is used to set the front right encoder to the true position
 	 */
 	public void setFrontRightEncoders() {
+		log("Steer FR Before: " + m_SteerFrontRight.getSensorPosition());
 		m_SteerFrontRight.setSensorPosition((int) Math
 				.round(2048.0 / 360.0 * (150.0 / 7.0) * e_FrontRight.getAbsolutePosition()));
+		log("Steer FR After: " + m_SteerFrontRight.getSensorPosition());
+
 	}
 
 	/**
@@ -657,7 +665,11 @@ public class Drive extends Mechanism {
 	@Override
 	public void run() {
 		currentPosition = swerveOdometry.run();
-		log(currentPosition.toString());
+		//log(currentPosition.toString());
+		SmartDashboard.putNumber("Front Right Motor Encoder", m_SteerFrontRight.getSensorPosition());
+		SmartDashboard.putNumber("Front Left Motor Encoder", m_SteerFrontLeft.getSensorPosition());
+		SmartDashboard.putNumber("Back Right Motor Encoder", m_SteerBackRight.getSensorPosition());
+		SmartDashboard.putNumber("Back Left Motor Encoder", m_SteerBackLeft.getSensorPosition());
 	}
 }
 

--- a/src/main/java/com/team766/robot/mechanisms/Gyro.java
+++ b/src/main/java/com/team766/robot/mechanisms/Gyro.java
@@ -2,7 +2,7 @@ package com.team766.robot.mechanisms;
 import edu.wpi.first.wpilibj.I2C;
 import edu.wpi.first.wpilibj.SerialPort;
 import edu.wpi.first.wpilibj.I2C.Port;
-
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import com.team766.framework.Mechanism;
 import com.team766.hal.EncoderReader;
 import com.team766.hal.RobotProvider;
@@ -47,6 +47,9 @@ public class Gyro extends Mechanism {
 			 gyroArray[0] = getGyroYaw();
 			 gyroArray[1] = getGyroPitch();
 			 gyroArray[2] = getGyroRoll();
+			 SmartDashboard.putNumber("Yaw", gyroArray[0]);
+			 SmartDashboard.putNumber("Pitch", gyroArray[1]);
+			 SmartDashboard.putNumber("Roll", gyroArray[2]);
 			 g_gyro.getYawPitchRoll(gyroArray);
 		 }
 	}


### PR DESCRIPTION
## Description

Fixed swerve issues:
* Absolute encoders inverted
* Set relative encoder values to absolute encoder


## How Has This Been Tested?

- [ ] Unit tests: [Add your description here]
- [ ] Simulator testing: [Add your description here]
- [x] On-robot bench testing: swerve wheels align and move correctly
- [x] On-robot field testing: robot drives around and moves in absolute space
