### PR TITLE
intake

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "java"
     id 'java-library'
     id 'maven-publish'
-    id "edu.wpi.first.GradleRIO" version "2023.2.1"
+    id "edu.wpi.first.GradleRIO" version "2023.4.2"
     id 'com.google.protobuf' version '0.8.19'
 }
 
@@ -40,6 +40,31 @@ deploy {
                 // getTargetTypeClass is a shortcut to get the class type using a string
 
                 frcJava(getArtifactTypeClass('FRCJavaArtifact')) {
+                    // This supposedly makes Java save a heap dump on OutOfMemoryError, but
+                    // unfortunately it doesn't seem to work when the error is raised due to a
+                    // native allocation. https://stackoverflow.com/q/27166267
+                    jvmArgs.add("-XX:+HeapDumpOnOutOfMemoryError")
+                    jvmArgs.add("-XX:HeapDumpPath=/home/lvuser")
+                    // This limits heap memory as a percentage (0-100) of physical memory size.
+                    // `MinRAMPercentage` is a misleading name, which suggests that it is used to
+                    // configure minimum heap size. Rather, the `-XX:MinRAMPercentage` JVM argument
+                    // will be used to compute the maximum Java heap size only if the overall memory
+                    // size in the physical machine is less than 250MB (approximately). Say suppose
+                    // you are configuring `-XX:MinRAMPercentage=50` and overall physical memory is
+                    // 100MB; then your java application's max heap size will be set to 50MB
+                    // (i.e., 50% of 100MB). `-XX:MaxRAMPercentage` has the same effect and applies
+                    // only when physical memory is larger than 250MB.
+                    // Effectively, this limit should apply to RoboRIO V1 (~240MB of RAM available),
+                    // but not RoboRIO V2 (~500MB of RAM available).
+                    // Without this, we get errors like
+                    //    OpenJDK Client VM warning: INFO: os::commit_memory(0xb3800000, 1048576, 0)
+                    //    failed; error='Not enough space' (errno=12)
+                    //    # There is insufficient memory for the Java Runtime Environment to continue.
+                    //    # Native memory allocation (mmap) failed to map 1048576 bytes for committing
+                    //    reserved memory.
+                    jvmArgs.add("-XX:MinRAMPercentage=15")
+                    // This makes the JVM print the heap memory size on startup.
+                    jvmArgs.add("-XshowSettings:vm")
                 }
 
                 // Static files artifact
@@ -93,13 +118,17 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 
     // our files
-    implementation "com.google.protobuf:protobuf-java:${protobufVersion}"
+    implementation "com.google.protobuf:protobuf-javalite:${protobufVersion}"
 
     implementation files('deps/commons-math3-3.6.1.jar')
     implementation files('deps/gral-core-0.11.jar')
     // implementation "org.java-websocket:Java-WebSocket:1.4.0"
     //implementation files('deps/Java-WebSocket-1.3.9.jar')
     implementation files('deps/json-20190722.jar')
+}
+
+javadoc {
+  source = sourceSets.main.allJava
 }
 
 test {
@@ -154,6 +183,22 @@ protobuf {
     // Download from repositories
     artifact = "com.google.protobuf:protoc:${protobufVersion}"
   }
+
+
+  plugins {
+    javalite {
+      // The codegen for lite comes as a separate artifact
+      artifact = 'com.google.protobuf:protoc-gen-javalite:${protobufVersion}'
+    }
+  }
+
+  generateProtoTasks {
+    all().configureEach { task ->
+      task.builtins {
+        java {
+          option "lite"
+        }
+      }
+    }
+  }
 }
-
-

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "java"
     id 'java-library'
     id 'maven-publish'
-    id "edu.wpi.first.GradleRIO" version "2023.4.2"
+    id "edu.wpi.first.GradleRIO" version "2023.2.1"
     id 'com.google.protobuf' version '0.8.19'
 }
 
@@ -40,31 +40,6 @@ deploy {
                 // getTargetTypeClass is a shortcut to get the class type using a string
 
                 frcJava(getArtifactTypeClass('FRCJavaArtifact')) {
-                    // This supposedly makes Java save a heap dump on OutOfMemoryError, but
-                    // unfortunately it doesn't seem to work when the error is raised due to a
-                    // native allocation. https://stackoverflow.com/q/27166267
-                    jvmArgs.add("-XX:+HeapDumpOnOutOfMemoryError")
-                    jvmArgs.add("-XX:HeapDumpPath=/home/lvuser")
-                    // This limits heap memory as a percentage (0-100) of physical memory size.
-                    // `MinRAMPercentage` is a misleading name, which suggests that it is used to
-                    // configure minimum heap size. Rather, the `-XX:MinRAMPercentage` JVM argument
-                    // will be used to compute the maximum Java heap size only if the overall memory
-                    // size in the physical machine is less than 250MB (approximately). Say suppose
-                    // you are configuring `-XX:MinRAMPercentage=50` and overall physical memory is
-                    // 100MB; then your java application's max heap size will be set to 50MB
-                    // (i.e., 50% of 100MB). `-XX:MaxRAMPercentage` has the same effect and applies
-                    // only when physical memory is larger than 250MB.
-                    // Effectively, this limit should apply to RoboRIO V1 (~240MB of RAM available),
-                    // but not RoboRIO V2 (~500MB of RAM available).
-                    // Without this, we get errors like
-                    //    OpenJDK Client VM warning: INFO: os::commit_memory(0xb3800000, 1048576, 0)
-                    //    failed; error='Not enough space' (errno=12)
-                    //    # There is insufficient memory for the Java Runtime Environment to continue.
-                    //    # Native memory allocation (mmap) failed to map 1048576 bytes for committing
-                    //    reserved memory.
-                    jvmArgs.add("-XX:MinRAMPercentage=15")
-                    // This makes the JVM print the heap memory size on startup.
-                    jvmArgs.add("-XshowSettings:vm")
                 }
 
                 // Static files artifact
@@ -118,17 +93,13 @@ dependencies {
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.8.2'
 
     // our files
-    implementation "com.google.protobuf:protobuf-javalite:${protobufVersion}"
+    implementation "com.google.protobuf:protobuf-java:${protobufVersion}"
 
     implementation files('deps/commons-math3-3.6.1.jar')
     implementation files('deps/gral-core-0.11.jar')
     // implementation "org.java-websocket:Java-WebSocket:1.4.0"
     //implementation files('deps/Java-WebSocket-1.3.9.jar')
     implementation files('deps/json-20190722.jar')
-}
-
-javadoc {
-  source = sourceSets.main.allJava
 }
 
 test {
@@ -182,24 +153,6 @@ protobuf {
   protoc {
     // Download from repositories
     artifact = "com.google.protobuf:protoc:${protobufVersion}"
-  }
-
-
-  plugins {
-    javalite {
-      // The codegen for lite comes as a separate artifact
-      artifact = 'com.google.protobuf:protoc-gen-javalite:${protobufVersion}'
-    }
-  }
-
-  generateProtoTasks {
-    all().configureEach { task ->
-      task.builtins {
-        java {
-          option "lite"
-        }
-      }
-    }
   }
 }
 

--- a/docs/Intake.md
+++ b/docs/Intake.md
@@ -1,0 +1,50 @@
+# Intake
+
+## What is Intake?
+
+The `Intake` mechanism controls the motors on the robot used to pick up game pieces.
+
+## How does mechanism work?
+
+The intake extends and retracts using two pneumatics. There is a motor connected to each set of wheels on the intake as well as the conveyor belt. The motors rotate the wheels and conveyor belt in order to pull in/push out game pieces.
+
+## Benefits of intake
+
+* **Fast -** The intake can quickly pick up and push out pieces.
+* **Wide range -** Game pieces do not have to be in an ultra-specific area to be picked up by the intake.
+
+## Limitations of intake
+
+* **Hardware -** Intakes are pretty bulky. Enough said.
+* **Non-specific Placement -** It is difficult to precisely place pieces using the intake.
+
+## How to use intake
+
+The intake can be controlled with buttons on the operator interface by using the following code in `OI.java`:
+
+	if (joystick0.getButton(inButton)) {
+			Robot.intake.startIntake();
+			Robot.storage.beltIn();
+	} else if (joystick0.getButton(outButton)) {
+			Robot.intake.reverseIntake();
+			Robot.storage.beltOut();
+	} else {
+			Robot.intake.stopIntake();
+			Robot.storage.beltIdle();
+	}
+
+### Initialization
+
+`Intake` and `Storage` are initialized in `Robot.java` with the following code:
+
+	public static Intake intake; 
+	public static Storage storage;
+
+	public static void robotInit() {
+		intake = new Intake();
+		storage = new Storage();
+	}
+
+### Running intake
+
+The intake runs in `OI.java` with buttons as inputs. No procedures are needed to use the mechanism.

--- a/src/main/java/com/team766/robot/OI.java
+++ b/src/main/java/com/team766/robot/OI.java
@@ -50,26 +50,149 @@ public class OI extends Procedure {
 		context.takeOwnership(Robot.grabber);
 		context.takeOwnership(Robot.storage);
 		context.takeOwnership(Robot.gyro);
-		
+
 		while (true) {
 			context.waitFor(() -> RobotProvider.instance.hasNewDriverStationData());
 			RobotProvider.instance.refreshDriverStationData();
 			LeftJoystick_X = Robot.drive.correctedJoysticks(joystick0.getAxis(0));
 			LeftJoystick_Y = Robot.drive.correctedJoysticks(joystick0.getAxis(1));
 			RightJoystick_X = Robot.drive.correctedJoysticks(joystick1.getAxis(0));;
-			// wait for driver station data (and refresh it using the WPILib APIs)
-			context.waitFor(() -> RobotProvider.instance.hasNewDriverStationData());
-			RobotProvider.instance.refreshDriverStationData();
+
+			// Add driver controls here - make sure to take/release ownership
+			// of mechanisms when appropriate.
+			/* if (joystick0.getButtonPressed(15)){
+				if (intakeState == IntakeState.IDLE){
+					Robot.intake.intakeIn();
+					Robot.storage.beltIn();
+					intakeState = IntakeState.SPINNINGIN;
+				} else {
+					Robot.intake.intakeIdle();
+					Robot.storage.beltIdle();
+					intakeState = IntakeState.IDLE;
+				}
+			}
+			if (joystick0.getButtonPressed(16)){
+				if (intakeState == IntakeState.IDLE){
+					Robot.intake.intakeOut();
+					Robot.storage.beltOut();
+					intakeState = IntakeState.SPINNINGOUT;
+				} else {
+					Robot.intake.intakeIdle();
+					Robot.storage.beltIdle();
+					intakeState = IntakeState.IDLE;
+				}
+			} */
+
+			Robot.drive.setGyro(-Robot.gyro.getGyroYaw());
+
+			if(Math.abs(joystick1.getAxis(InputConstants.AXIS_FORWARD_BACKWARD)) > 0.05){
+				RightJoystick_Y = joystick1.getAxis(InputConstants.AXIS_FORWARD_BACKWARD);
+			} else {
+				RightJoystick_Y = 0;
+			}
+			if(Math.abs(joystick1.getAxis(InputConstants.AXIS_LEFT_RIGHT)) > 0.05){
+				RightJoystick_X = joystick1.getAxis(InputConstants.AXIS_LEFT_RIGHT)/2;
+				if(joystick1.getButton(3)){
+					RightJoystick_X *= 2;
+				}	
+			} else {
+				RightJoystick_X = 0;	
+			}
+			if(Math.abs(joystick1.getAxis(InputConstants.AXIS_TWIST)) > 0.05){
+				RightJoystick_Theta = joystick1.getAxis(InputConstants.AXIS_TWIST);
+			} else {
+				RightJoystick_Theta = 0;
+			}
+			if(Math.abs(joystick0.getAxis(InputConstants.AXIS_FORWARD_BACKWARD)) > 0.05){
+				LeftJoystick_Y = joystick0.getAxis(InputConstants.AXIS_FORWARD_BACKWARD);
+			} else {
+				LeftJoystick_Y = 0;
+			}
+			if(Math.abs(joystick0.getAxis(InputConstants.AXIS_LEFT_RIGHT)) > 0.05){
+				LeftJoystick_X = joystick0.getAxis(InputConstants.AXIS_LEFT_RIGHT);
+			} else {
+				LeftJoystick_X = 0;
+			}
+			if(Math.abs(joystick0.getAxis(InputConstants.AXIS_TWIST)) > 0.05){
+				LeftJoystick_Theta = joystick0.getAxis(InputConstants.AXIS_TWIST);
+			} else {
+				LeftJoystick_Theta = 0;
+			}
+
+						//log(Robot.gyro.getGyroYaw());			
+			//TODO: fix defense: the robot basically locks up if there is defense
+			// if(joystick0.getButton(InputConstants.CROSS_DEFENSE)){
+			// 	context.startAsync(new DefenseCross());
+			// }
+			
+			/*if(Math.pow(Math.pow(joystick0.getAxis(InputConstants.AXIS_LEFT_RIGHT),2) + Math.pow(joystick0.getAxis(InputConstants.AXIS_FORWARD_BACKWARD),2), 0.5) > 0.15 ){
+				Robot.drive.drive2D(
+					((joystick0.getAxis(InputConstants.AXIS_LEFT_RIGHT))),
+					((joystick0.getAxis(InputConstants.AXIS_FORWARD_BACKWARD)))
+				);
+			}  else {
+				if(Math.abs(joystick0.getAxis(InputConstants.AXIS_TWIST))>=0.1){
+					Robot.drive.turning(joystick0.getAxis(InputConstants.AXIS_TWIST));
+				} else {
+				Robot.drive.stopDriveMotors();
+				Robot.drive.stopSteerMotors();
+				}
+			}*/
+			if(joystick0.getButtonPressed(1))
+				Robot.gyro.resetGyro();
+
+			if(joystick0.getButtonPressed(11))
+				Robot.drive.resetCurrentPosition();
+
+			if(joystick1.getButtonPressed(1))
+				isCross = !isCross;
+			
+			
+			if(joystick0.getButtonPressed(2)){
+				Robot.drive.setFrontRightEncoders();
+				Robot.drive.setFrontLeftEncoders();
+				Robot.drive.setBackRightEncoders();
+				Robot.drive.setBackLeftEncoders();
+			}
+
+			// if(joystick1.getButton(1)){
+			// 	turningValue = joystick1.getAxis(InputConstants.AXIS_LEFT_RIGHT); 
+			// } else {
+			// 	turningValue = 0;
+			// }
+
+			SmartDashboard.putNumber("Front left", Robot.drive.getFrontLeft());
+			SmartDashboard.putNumber("Front right", Robot.drive.getFrontRight());
+			SmartDashboard.putNumber("Back left", Robot.drive.getBackLeft());
+			SmartDashboard.putNumber("Back right", Robot.drive.getBackRight());
+
+			if (isCross)  {
+				context.startAsync(new setCross());
+			} else if (joystick0.getButton(3)) {
+				Robot.drive.swerveDrive(0, 0.2, 0);
+			} else if (Math.abs(LeftJoystick_X) + Math.abs(LeftJoystick_Y) +  Math.abs(RightJoystick_X) > 0) {
+				Robot.drive.swerveDrive( 
+					(LeftJoystick_X),
+			 		(-LeftJoystick_Y),
+			 		(RightJoystick_X));
+			} else {
+				Robot.drive.stopDriveMotors();
+				Robot.drive.stopSteerMotors();				
+			} 
+			
+			if (joystick0.getButtonPressed(1)) {
+				Robot.gyro.resetGyro();
+			}
 
 			// Add driver controls here - make sure to take/release ownership
 			// of mechanisms when appropriate.
 			context.takeOwnership(Robot.intake);
 			context.takeOwnership(Robot.storage);
 
-			if(joystick0.getButton(inButton)){
+			if (joystick0.getButton(inButton)) {
 				Robot.intake.startIntake();
 				Robot.storage.beltIn();
-			} else if(joystick0.getButton(outButton)){
+			} else if (joystick0.getButton(outButton)) {
 				Robot.intake.reverseIntake();
 				Robot.storage.beltOut();
 			} else {

--- a/src/main/java/com/team766/robot/OI.java
+++ b/src/main/java/com/team766/robot/OI.java
@@ -36,10 +36,14 @@ public class OI extends Procedure {
 			context.takeOwnership(Robot.intake);
 			context.takeOwnership(Robot.storage);
 
-			if(joystick0.getButton(5)){
+			//setting buttons to use
+			int inButton = 5;
+			int outButton = 10;
+
+			if(joystick0.getButton(inButton)){
 				Robot.intake.startIntake();
 				Robot.storage.beltIn();
-			} else if(joystick0.getButton(10)){
+			} else if(joystick0.getButton(outButton)){
 				Robot.intake.reverseIntake();
 				Robot.storage.beltOut();
 			} else {

--- a/src/main/java/com/team766/robot/OI.java
+++ b/src/main/java/com/team766/robot/OI.java
@@ -12,6 +12,7 @@ import com.team766.robot.constants.InputConstants;
 import com.team766.robot.procedures.*;
 import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
+import com.team766.robot.mechanisms.Drive;
 
 /**
  * This class is the glue that binds the controls on the physical operator
@@ -21,12 +22,12 @@ public class OI extends Procedure {
 	private JoystickReader joystick0;
 	private JoystickReader joystick1;
 	private JoystickReader joystick2;
-	private double RightJoystick_X = 0;
+	private double rightJoystickX = 0;
 	private double RightJoystick_Y = 0;
 	private double RightJoystick_Z = 0;
 	private double RightJoystick_Theta = 0;
-	private double LeftJoystick_X = 0;
-	private double LeftJoystick_Y = 0;
+	private double leftJoystickX = 0;
+	private double leftJoystickY = 0;
 	private double LeftJoystick_Z = 0;
 	private double LeftJoystick_Theta = 0;
 	private boolean isCross = false;
@@ -54,9 +55,9 @@ public class OI extends Procedure {
 		while (true) {
 			context.waitFor(() -> RobotProvider.instance.hasNewDriverStationData());
 			RobotProvider.instance.refreshDriverStationData();
-			LeftJoystick_X = Robot.drive.correctedJoysticks(joystick0.getAxis(0));
-			LeftJoystick_Y = Robot.drive.correctedJoysticks(joystick0.getAxis(1));
-			RightJoystick_X = Robot.drive.correctedJoysticks(joystick1.getAxis(0));;
+			leftJoystickX = Drive.correctedJoysticks(joystick0.getAxis(0));
+			leftJoystickY = Drive.correctedJoysticks(joystick0.getAxis(1));
+			rightJoystickX = Drive.correctedJoysticks(joystick1.getAxis(0));;
 
 			// Add driver controls here - make sure to take/release ownership
 			// of mechanisms when appropriate.
@@ -85,35 +86,35 @@ public class OI extends Procedure {
 
 			Robot.drive.setGyro(-Robot.gyro.getGyroYaw());
 
-			if(Math.abs(joystick1.getAxis(InputConstants.AXIS_FORWARD_BACKWARD)) > 0.05){
+			if (Math.abs(joystick1.getAxis(InputConstants.AXIS_FORWARD_BACKWARD)) > 0.05) {
 				RightJoystick_Y = joystick1.getAxis(InputConstants.AXIS_FORWARD_BACKWARD);
 			} else {
 				RightJoystick_Y = 0;
 			}
-			if(Math.abs(joystick1.getAxis(InputConstants.AXIS_LEFT_RIGHT)) > 0.05){
-				RightJoystick_X = joystick1.getAxis(InputConstants.AXIS_LEFT_RIGHT)/2;
+			if (Math.abs(joystick1.getAxis(InputConstants.AXIS_LEFT_RIGHT)) > 0.05) {
+				rightJoystickX = joystick1.getAxis(InputConstants.AXIS_LEFT_RIGHT)/2;
 				if(joystick1.getButton(3)){
-					RightJoystick_X *= 2;
+					rightJoystickX *= 2;
 				}	
 			} else {
-				RightJoystick_X = 0;	
+				rightJoystickX = 0;	
 			}
-			if(Math.abs(joystick1.getAxis(InputConstants.AXIS_TWIST)) > 0.05){
+			if (Math.abs(joystick1.getAxis(InputConstants.AXIS_TWIST)) > 0.05) {
 				RightJoystick_Theta = joystick1.getAxis(InputConstants.AXIS_TWIST);
 			} else {
 				RightJoystick_Theta = 0;
 			}
-			if(Math.abs(joystick0.getAxis(InputConstants.AXIS_FORWARD_BACKWARD)) > 0.05){
-				LeftJoystick_Y = joystick0.getAxis(InputConstants.AXIS_FORWARD_BACKWARD);
+			if (Math.abs(joystick0.getAxis(InputConstants.AXIS_FORWARD_BACKWARD)) > 0.05) {
+				leftJoystickY = joystick0.getAxis(InputConstants.AXIS_FORWARD_BACKWARD);
 			} else {
-				LeftJoystick_Y = 0;
+				leftJoystickY = 0;
 			}
-			if(Math.abs(joystick0.getAxis(InputConstants.AXIS_LEFT_RIGHT)) > 0.05){
-				LeftJoystick_X = joystick0.getAxis(InputConstants.AXIS_LEFT_RIGHT);
+			if (Math.abs(joystick0.getAxis(InputConstants.AXIS_LEFT_RIGHT)) > 0.05) {
+				leftJoystickX = joystick0.getAxis(InputConstants.AXIS_LEFT_RIGHT);
 			} else {
-				LeftJoystick_X = 0;
+				leftJoystickX = 0;
 			}
-			if(Math.abs(joystick0.getAxis(InputConstants.AXIS_TWIST)) > 0.05){
+			if (Math.abs(joystick0.getAxis(InputConstants.AXIS_TWIST)) > 0.05) {
 				LeftJoystick_Theta = joystick0.getAxis(InputConstants.AXIS_TWIST);
 			} else {
 				LeftJoystick_Theta = 0;
@@ -138,17 +139,20 @@ public class OI extends Procedure {
 				Robot.drive.stopSteerMotors();
 				}
 			}*/
-			if(joystick0.getButtonPressed(1))
+			if (joystick0.getButtonPressed(1)) {
 				Robot.gyro.resetGyro();
+			}
 
-			if(joystick0.getButtonPressed(11))
+			if (joystick0.getButtonPressed(11)) {
 				Robot.drive.resetCurrentPosition();
+			}
 
-			if(joystick1.getButtonPressed(1))
+			if (joystick1.getButtonPressed(1)) {
 				isCross = !isCross;
+			}
 			
 			
-			if(joystick0.getButtonPressed(2)){
+			if (joystick0.getButtonPressed(2)) {
 				Robot.drive.setFrontRightEncoders();
 				Robot.drive.setFrontLeftEncoders();
 				Robot.drive.setBackRightEncoders();
@@ -166,15 +170,12 @@ public class OI extends Procedure {
 			SmartDashboard.putNumber("Back left", Robot.drive.getBackLeft());
 			SmartDashboard.putNumber("Back right", Robot.drive.getBackRight());
 
-			if (isCross)  {
+			if (isCross) {
 				context.startAsync(new setCross());
 			} else if (joystick0.getButton(3)) {
 				Robot.drive.swerveDrive(0, 0.2, 0);
-			} else if (Math.abs(LeftJoystick_X) + Math.abs(LeftJoystick_Y) +  Math.abs(RightJoystick_X) > 0) {
-				Robot.drive.swerveDrive( 
-					(LeftJoystick_X),
-			 		(-LeftJoystick_Y),
-			 		(RightJoystick_X));
+			} else if (Math.abs(leftJoystickX) + Math.abs(leftJoystickY) +  Math.abs(rightJoystickX) > 0) {
+				Robot.drive.swerveDrive( (leftJoystickX), (-leftJoystickY), (rightJoystickX) );
 			} else {
 				Robot.drive.stopDriveMotors();
 				Robot.drive.stopSteerMotors();				

--- a/src/main/java/com/team766/robot/OI.java
+++ b/src/main/java/com/team766/robot/OI.java
@@ -37,14 +37,14 @@ public class OI extends Procedure {
 			context.takeOwnership(Robot.storage);
 
 			if(joystick0.getButton(5)){
-				Robot.intake.IntakeIn();
-				Robot.belt.beltIn();
+				Robot.intake.startIntake();
+				Robot.storage.beltIn();
 			} else if(joystick0.getButton(10)){
-				Robot.intake.IntakeOut();
-				Robot.belt.beltOut();
+				Robot.intake.reverseIntake();
+				Robot.storage.beltOut();
 			} else {
 				Robot.intake.stopIntake();
-				Robot.belt.beltIdle();
+				Robot.storage.beltIdle();
 			}
 
 

--- a/src/main/java/com/team766/robot/OI.java
+++ b/src/main/java/com/team766/robot/OI.java
@@ -1,12 +1,17 @@
 package com.team766.robot;
 
+import java.io.IOException;
+
 import com.team766.framework.Procedure;
+
 import com.team766.framework.Context;
 import com.team766.hal.JoystickReader;
 import com.team766.hal.RobotProvider;
 import com.team766.logging.Category;
+import com.team766.robot.constants.InputConstants;
 import com.team766.robot.procedures.*;
 import edu.wpi.first.wpilibj.DriverStation;
+import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 /**
  * This class is the glue that binds the controls on the physical operator
@@ -16,6 +21,16 @@ public class OI extends Procedure {
 	private JoystickReader joystick0;
 	private JoystickReader joystick1;
 	private JoystickReader joystick2;
+	private double RightJoystick_X = 0;
+	private double RightJoystick_Y = 0;
+	private double RightJoystick_Z = 0;
+	private double RightJoystick_Theta = 0;
+	private double LeftJoystick_X = 0;
+	private double LeftJoystick_Y = 0;
+	private double LeftJoystick_Z = 0;
+	private double LeftJoystick_Theta = 0;
+	private boolean isCross = false;
+	double turningValue = 0;
 	//setting buttons to use
 	private int inButton = 5;
 	private int outButton = 10;
@@ -29,7 +44,19 @@ public class OI extends Procedure {
 	}
 	
 	public void run(Context context) {
+		context.takeOwnership(Robot.drive);
+		context.takeOwnership(Robot.intake);
+		context.takeOwnership(Robot.arms);
+		context.takeOwnership(Robot.grabber);
+		context.takeOwnership(Robot.storage);
+		context.takeOwnership(Robot.gyro);
+		
 		while (true) {
+			context.waitFor(() -> RobotProvider.instance.hasNewDriverStationData());
+			RobotProvider.instance.refreshDriverStationData();
+			LeftJoystick_X = Robot.drive.correctedJoysticks(joystick0.getAxis(0));
+			LeftJoystick_Y = Robot.drive.correctedJoysticks(joystick0.getAxis(1));
+			RightJoystick_X = Robot.drive.correctedJoysticks(joystick1.getAxis(0));;
 			// wait for driver station data (and refresh it using the WPILib APIs)
 			context.waitFor(() -> RobotProvider.instance.hasNewDriverStationData());
 			RobotProvider.instance.refreshDriverStationData();

--- a/src/main/java/com/team766/robot/OI.java
+++ b/src/main/java/com/team766/robot/OI.java
@@ -16,6 +16,9 @@ public class OI extends Procedure {
 	private JoystickReader joystick0;
 	private JoystickReader joystick1;
 	private JoystickReader joystick2;
+	//setting buttons to use
+	private int inButton = 5;
+	private int outButton = 10;
 	
 	public OI() {
 		loggerCategory = Category.OPERATOR_INTERFACE;
@@ -35,10 +38,6 @@ public class OI extends Procedure {
 			// of mechanisms when appropriate.
 			context.takeOwnership(Robot.intake);
 			context.takeOwnership(Robot.storage);
-
-			//setting buttons to use
-			int inButton = 5;
-			int outButton = 10;
 
 			if(joystick0.getButton(inButton)){
 				Robot.intake.startIntake();

--- a/src/main/java/com/team766/robot/OI.java
+++ b/src/main/java/com/team766/robot/OI.java
@@ -1,17 +1,12 @@
 package com.team766.robot;
 
 import com.team766.framework.Procedure;
-
-import java.io.IOException;
-
 import com.team766.framework.Context;
 import com.team766.hal.JoystickReader;
 import com.team766.hal.RobotProvider;
 import com.team766.logging.Category;
-import com.team766.robot.constants.InputConstants;
 import com.team766.robot.procedures.*;
 import edu.wpi.first.wpilibj.DriverStation;
-import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 
 /**
  * This class is the glue that binds the controls on the physical operator
@@ -21,180 +16,24 @@ public class OI extends Procedure {
 	private JoystickReader joystick0;
 	private JoystickReader joystick1;
 	private JoystickReader joystick2;
-	private double RightJoystick_X = 0;
-	private double RightJoystick_Y = 0;
-	private double RightJoystick_Z = 0;
-	private double RightJoystick_Theta = 0;
-	private double LeftJoystick_X = 0;
-	private double LeftJoystick_Y = 0;
-	private double LeftJoystick_Z = 0;
-	private double LeftJoystick_Theta = 0;
-	private boolean isCross = false;
-	double turningValue = 0;
 	
-	enum IntakeState {
-		IDLE,
-		SPINNINGOUT,
-		SPINNINGIN
-	}
-	IntakeState intakeState = IntakeState.IDLE;
-
 	public OI() {
 		loggerCategory = Category.OPERATOR_INTERFACE;
 
 		joystick0 = RobotProvider.instance.getJoystick(0);
 		joystick1 = RobotProvider.instance.getJoystick(1);
 		joystick2 = RobotProvider.instance.getJoystick(2);
-
 	}
 	
 	public void run(Context context) {
-		context.takeOwnership(Robot.drive);
-		context.takeOwnership(Robot.intake);
-		context.takeOwnership(Robot.arms);
-		context.takeOwnership(Robot.grabber);
-		context.takeOwnership(Robot.storage);
-		context.takeOwnership(Robot.gyro);
-		
 		while (true) {
 			// wait for driver station data (and refresh it using the WPILib APIs)
 			context.waitFor(() -> RobotProvider.instance.hasNewDriverStationData());
 			RobotProvider.instance.refreshDriverStationData();
-			LeftJoystick_X = Robot.drive.correctedJoysticks(joystick0.getAxis(0));
-			LeftJoystick_Y = Robot.drive.correctedJoysticks(joystick0.getAxis(1));
-			RightJoystick_X = Robot.drive.correctedJoysticks(joystick1.getAxis(0));;
 
-			
 			// Add driver controls here - make sure to take/release ownership
 			// of mechanisms when appropriate.
-			/* if (joystick0.getButtonPressed(15)){
-				if (intakeState == IntakeState.IDLE){
-					Robot.intake.intakeIn();
-					Robot.storage.beltIn();
-					intakeState = IntakeState.SPINNINGIN;
-				} else {
-					Robot.intake.intakeIdle();
-					Robot.storage.beltIdle();
-					intakeState = IntakeState.IDLE;
-				}
-			}
-
-			if (joystick0.getButtonPressed(16)){
-				if (intakeState == IntakeState.IDLE){
-					Robot.intake.intakeOut();
-					Robot.storage.beltOut();
-					intakeState = IntakeState.SPINNINGOUT;
-				} else {
-					Robot.intake.intakeIdle();
-					Robot.storage.beltIdle();
-					intakeState = IntakeState.IDLE;
-				}
-			} */
-
-			
-				Robot.drive.setGyro(-Robot.gyro.getGyroYaw());
-				
-
-			if(Math.abs(joystick1.getAxis(InputConstants.AXIS_FORWARD_BACKWARD)) > 0.05){
-				RightJoystick_Y = joystick1.getAxis(InputConstants.AXIS_FORWARD_BACKWARD);
-			} else {
-				RightJoystick_Y = 0;
-			}
-			if(Math.abs(joystick1.getAxis(InputConstants.AXIS_LEFT_RIGHT)) > 0.05){
-				RightJoystick_X = joystick1.getAxis(InputConstants.AXIS_LEFT_RIGHT)/2;
-				if(joystick1.getButton(3)){
-					RightJoystick_X *= 2;
-				}	
-			} else {
-				RightJoystick_X = 0;	
-			}
-			if(Math.abs(joystick1.getAxis(InputConstants.AXIS_TWIST)) > 0.05){
-				RightJoystick_Theta = joystick1.getAxis(InputConstants.AXIS_TWIST);
-			} else {
-				RightJoystick_Theta = 0;
-			}
-			if(Math.abs(joystick0.getAxis(InputConstants.AXIS_FORWARD_BACKWARD)) > 0.05){
-				LeftJoystick_Y = joystick0.getAxis(InputConstants.AXIS_FORWARD_BACKWARD);
-			} else {
-				LeftJoystick_Y = 0;
-			}
-			if(Math.abs(joystick0.getAxis(InputConstants.AXIS_LEFT_RIGHT)) > 0.05){
-				LeftJoystick_X = joystick0.getAxis(InputConstants.AXIS_LEFT_RIGHT);
-			} else {
-				LeftJoystick_X = 0;
-			}
-			if(Math.abs(joystick0.getAxis(InputConstants.AXIS_TWIST)) > 0.05){
-				LeftJoystick_Theta = joystick0.getAxis(InputConstants.AXIS_TWIST);
-			} else {
-				LeftJoystick_Theta = 0;
-			}
-			//log(Robot.gyro.getGyroYaw());			
-			//TODO: fix defense: the robot basically locks up if there is defense
-			// if(joystick0.getButton(InputConstants.CROSS_DEFENSE)){
-			// 	context.startAsync(new DefenseCross());
-			// }
-			
-			/*if(Math.pow(Math.pow(joystick0.getAxis(InputConstants.AXIS_LEFT_RIGHT),2) + Math.pow(joystick0.getAxis(InputConstants.AXIS_FORWARD_BACKWARD),2), 0.5) > 0.15 ){
-				Robot.drive.drive2D(
-					((joystick0.getAxis(InputConstants.AXIS_LEFT_RIGHT))),
-					((joystick0.getAxis(InputConstants.AXIS_FORWARD_BACKWARD)))
-				);
-			}  else {
-				if(Math.abs(joystick0.getAxis(InputConstants.AXIS_TWIST))>=0.1){
-					Robot.drive.turning(joystick0.getAxis(InputConstants.AXIS_TWIST));
-				} else {
-				Robot.drive.stopDriveMotors();
-				Robot.drive.stopSteerMotors();
-				}
-			}*/
-			if(joystick0.getButtonPressed(1))
-				Robot.gyro.resetGyro();
-
-			if(joystick0.getButtonPressed(11))
-				Robot.drive.resetCurrentPosition();
-
-			if(joystick1.getButtonPressed(1))
-				isCross = !isCross;
-			
-			
-			if(joystick0.getButtonPressed(2)){
-				Robot.drive.setFrontRightEncoders();
-				Robot.drive.setFrontLeftEncoders();
-				Robot.drive.setBackRightEncoders();
-				Robot.drive.setBackLeftEncoders();
-			}
-			// if(joystick1.getButton(1)){
-			// 	turningValue = joystick1.getAxis(InputConstants.AXIS_LEFT_RIGHT); 
-			// } else {
-			// 	turningValue = 0;
-			// }
-
-			SmartDashboard.putNumber("Front left", Robot.drive.getFrontLeft());
-			SmartDashboard.putNumber("Front right", Robot.drive.getFrontRight());
-			SmartDashboard.putNumber("Back left", Robot.drive.getBackLeft());
-			SmartDashboard.putNumber("Back right", Robot.drive.getBackRight());
-
-			if (isCross)  {
-				context.startAsync(new setCross());
-			} else if (joystick0.getButton(3)) {
-				Robot.drive.swerveDrive(0, 0.2, 0);
-			} else if(Math.abs(LeftJoystick_X)+
-			Math.abs(LeftJoystick_Y) +  Math.abs(RightJoystick_X) > 0) {
-				Robot.drive.swerveDrive( 
-					(LeftJoystick_X),
-			 		(-LeftJoystick_Y),
-			 		(RightJoystick_X));
-			} else {
-				Robot.drive.stopDriveMotors();
-				Robot.drive.stopSteerMotors();				
-			} 
-			
-		
-			
-			if(joystick0.getButtonPressed(1))
-				Robot.gyro.resetGyro();
-
-
+			context.takeOwnership(Robot.intake);
 		}
 	}
 }

--- a/src/main/java/com/team766/robot/OI.java
+++ b/src/main/java/com/team766/robot/OI.java
@@ -34,6 +34,19 @@ public class OI extends Procedure {
 			// Add driver controls here - make sure to take/release ownership
 			// of mechanisms when appropriate.
 			context.takeOwnership(Robot.intake);
+
+			if(joystick0.getButton(1)){
+				Robot.intake.IntakeIn();
+			} else {
+				Robot.intake.stopIntake();
+			}
+
+			if(joystick0.getButton(2)){
+				Robot.intake.IntakeOut();
+			} else {
+				Robot.intake.stopIntake();
+			}
+
 		}
 	}
 }

--- a/src/main/java/com/team766/robot/OI.java
+++ b/src/main/java/com/team766/robot/OI.java
@@ -34,18 +34,19 @@ public class OI extends Procedure {
 			// Add driver controls here - make sure to take/release ownership
 			// of mechanisms when appropriate.
 			context.takeOwnership(Robot.intake);
+			context.takeOwnership(Robot.storage);
 
-			if(joystick0.getButton(1)){
+			if(joystick0.getButton(5)){
 				Robot.intake.IntakeIn();
+				Robot.belt.beltIn();
+			} else if(joystick0.getButton(10)){
+				Robot.intake.IntakeOut();
+				Robot.belt.beltOut();
 			} else {
 				Robot.intake.stopIntake();
+				Robot.belt.beltIdle();
 			}
 
-			if(joystick0.getButton(2)){
-				Robot.intake.IntakeOut();
-			} else {
-				Robot.intake.stopIntake();
-			}
 
 		}
 	}

--- a/src/main/java/com/team766/robot/Robot.java
+++ b/src/main/java/com/team766/robot/Robot.java
@@ -6,10 +6,18 @@ public class Robot {
 	// Declare mechanisms here
 	public static Intake intake; 
 	public static Storage storage;
+	public static Drive drive;
+	public static Grabber grabber;
+	public static Arms arms;
+	public static Gyro gyro;
 
 	public static void robotInit() {
 		// Initialize mechanisms here
 		intake = new Intake();
 		storage = new Storage();
+		drive = new Drive();
+		grabber = new Grabber();
+		arms = new Arms();
+		gyro = new Gyro();
 	}
 }

--- a/src/main/java/com/team766/robot/Robot.java
+++ b/src/main/java/com/team766/robot/Robot.java
@@ -4,23 +4,10 @@ import com.team766.robot.mechanisms.*;
 
 public class Robot {
 	// Declare mechanisms here
-	public static Drive drive;
-	public static Gyro gyro;
-	public static CANdleMech candle;
-	public static Intake intake;
-	public static Storage storage;
-	public static Arms arms;
-	public static Grabber grabber;
+	public static Intake intake; 
 
 	public static void robotInit() {
 		// Initialize mechanisms here
-		drive = new Drive();
-		gyro = new Gyro();
-		candle = new CANdleMech();
 		intake = new Intake();
-		storage = new Storage();
-		arms = new Arms();
-		grabber = new Grabber();
-
 	}
 }

--- a/src/main/java/com/team766/robot/Robot.java
+++ b/src/main/java/com/team766/robot/Robot.java
@@ -5,9 +5,11 @@ import com.team766.robot.mechanisms.*;
 public class Robot {
 	// Declare mechanisms here
 	public static Intake intake; 
+	public static Storage storage;
 
 	public static void robotInit() {
 		// Initialize mechanisms here
 		intake = new Intake();
+		storage = new Storage();
 	}
 }

--- a/src/main/java/com/team766/robot/mechanisms/Drive.java
+++ b/src/main/java/com/team766/robot/mechanisms/Drive.java
@@ -233,10 +233,11 @@ public class Drive extends Mechanism {
 	 * @returnThe corrected joystick value
 	 */
 	public static double correctedJoysticks(double Joystick) {
-		if (Joystick >= 0)
+		if (Joystick >= 0) {
 			return (3.0 * Math.pow(Joystick, 2) - 2.0 * Math.pow(Joystick, 3));
-		else
+		} else {
 			return (-1 * 3.0 * Math.pow(-1 * Joystick, 2) + 2.0 * Math.pow(-1 * Joystick, 3));
+		}
 	}
 
 	/**

--- a/src/main/java/com/team766/robot/mechanisms/Intake.java
+++ b/src/main/java/com/team766/robot/mechanisms/Intake.java
@@ -1,47 +1,43 @@
 package com.team766.frc2022.mechanisms;
 
-import com.team766.config.ConfigFileReader;
 import com.team766.framework.Mechanism;
-import com.team766.hal.SolenoidController;
-import com.team766.hal.CANSpeedController;
+import com.team766.hal.MotorController;
 import com.team766.hal.RobotProvider;
-import com.team766.hal.wpilib.DigitalInput;
+import com.team766.hal.SolenoidController;
+import com.team766.hal.wpilib.CANSparkMaxMotorController;
+import com.team766.hal.wpilib.Solenoid;
 
 public class Intake extends Mechanism {
-	private SolenoidController intakeArm1;
-	private SolenoidController intakeArm2;
-	private MotorController topIntakeWheels;
-	private MotorController bottomIntakeWheels;
-	private MotorController conveyorBelt;
+	private SolenoidController leftPiston;
+	private SolenoidController rightPiston;
+	private MotorController topBelt;
+	private MotorController bottomWheels;
 	private boolean beltGoing = false;
 	
 	public Intake() {
-		topIntakeWheels = RobotProvider.instance.getMotor("Intake.topWheels");
-		bottomIntakeWheels = RobotProvider.instance.getMotor("Intake.bottomWheels");
-		conveyorBelt = RobotProvider.instance.getMotor("Intake.conveyorBelt");
+		topBelt = RobotProvider.instance.getMotor("Intake.topWheels");
+		bottomWheels = RobotProvider.instance.getMotor("Intake.bottomWheels");
 
-		intakeArm1 = RobotProvider.instance.getSolenoid("Intake.leftPiston");
-		intakeArm2 = RobotProvider.instance.getSolenoid("Intake.rightPiston");
+		leftPiston = RobotProvider.instance.getSolenoid("Intake.leftPiston");
+		rightPiston = RobotProvider.instance.getSolenoid("Intake.rightPiston");
 
 	}
 
 	public void startIntake() {
 		checkContextOwnership();
-		double power = ConfigFileReader.getInstance().getDouble("Intake.intakePower").get();
+		//double power = ConfigFileReader.getInstance().getDouble("Intake.intakePower").get();
 		
 		startArms();
-		topIntakeWheels.set(power);
-		bottomIntakeWheels.set(power);
-		conveyorBelt.set(power*0.5);
+		topBelt.set(1.0);
+		bottomWheels.set(1.0);
 
 	}
 
 	public void stopIntake() {
 		checkContextOwnership();
 		
-		topIntakeWheels.set(0.0);
-		bottomIntakeWheels.set(0.0);
-		conveyorBelt.set(0.0);
+		topBelt.set(0.0);
+		bottomWheels.set(0.0);
 		stopArms();
 	}
 	/*
@@ -53,15 +49,15 @@ public class Intake extends Mechanism {
 	* double power = ConfigFileReader.getInstance().getDouble("Intake.intakePower").get();
     *
 	* if(beltGoing){
-	*	topIntakeWheels.set(0.0);
-	*   bottomIntakeWheels.set(0.0);
+	*	topBelt.set(0.0);
+	*   bottomWheels.set(0.0);
 	*	conveyorBelt.set(0.0);
 	*	stopArms();
 	* } else {
 	*	startArms();
-	*	topIntakeWheels.set(power);
-	*	bottomIntakeWheels.set(power);
-	*	conveyorBelt.set(power);
+	*	topBelt.set(1.0);
+	*	bottomWheels.set(1.0);
+	*	conveyorBelt.set(1.0);
 	* }
 	* a different method will check if the sensor sees stuff
 	* if(sensor1.getStorage || sensor2.getStrorage) stop the motors and arms
@@ -70,24 +66,23 @@ public class Intake extends Mechanism {
 	public void startArms(){
 		checkContextOwnership();
 
-		intakeArm1.set(true);
-		intakeArm2.set(true);
+		leftPiston.set(true);
+		rightPiston.set(true);
 	}
 
 	public void stopArms(){
 		checkContextOwnership();
 
-		intakeArm1.set(false);
-		intakeArm2.set(false);
+		leftPiston.set(false);
+		rightPiston.set(false);
 	}
 
 	public void reverseIntake(){
 		checkContextOwnership();
-		double power = ConfigFileReader.getInstance().getDouble("Intake.intakePower").get();
+		//double power = ConfigFileReader.getInstance().getDouble("Intake.intakePower").get();
 
-		topIntakeWheels.set(-power);
-		bottomIntakeWheels.set(-power);
-		conveyorBelt.set(-power*0.5);
+		topBelt.set(-1.0);
+		bottomWheels.set(-1.0);
 
 		startArms();
 	}

--- a/src/main/java/com/team766/robot/mechanisms/Intake.java
+++ b/src/main/java/com/team766/robot/mechanisms/Intake.java
@@ -1,11 +1,9 @@
-package com.team766.frc2022.mechanisms;
+package com.team766.robot.mechanisms;
 
 import com.team766.framework.Mechanism;
 import com.team766.hal.MotorController;
 import com.team766.hal.RobotProvider;
 import com.team766.hal.SolenoidController;
-import com.team766.hal.wpilib.CANSparkMaxMotorController;
-import com.team766.hal.wpilib.Solenoid;
 
 public class Intake extends Mechanism {
 	private SolenoidController leftPiston;

--- a/src/main/java/com/team766/robot/mechanisms/Intake.java
+++ b/src/main/java/com/team766/robot/mechanisms/Intake.java
@@ -64,7 +64,7 @@ public class Intake extends Mechanism {
 	*	conveyorBelt.set(power);
 	* }
 	* a different method will check if the sensor sees stuff
-	* if(colorSensor.getStorage) stop the motors and arms
+	* if(sensor1.getStorage || sensor2.getStrorage) stop the motors and arms
 	*/
 
 	public void startArms(){

--- a/src/main/java/com/team766/robot/mechanisms/Intake.java
+++ b/src/main/java/com/team766/robot/mechanisms/Intake.java
@@ -40,21 +40,21 @@ public class Intake extends Mechanism {
 		pistonsIn();
 	}
 
-	public void pistonsOut(){
+	public void pistonsOut() {
 		checkContextOwnership();
 
 		leftPiston.set(true);
 		rightPiston.set(true);
 	}
 
-	public void pistonsIn(){
+	public void pistonsIn() {
 		checkContextOwnership();
 
 		leftPiston.set(false);
 		rightPiston.set(false);
 	}
 
-	public void reverseIntake(){
+	public void reverseIntake() {
 		checkContextOwnership();
 
 		topBelt.set(-1.0);

--- a/src/main/java/com/team766/robot/mechanisms/Intake.java
+++ b/src/main/java/com/team766/robot/mechanisms/Intake.java
@@ -13,20 +13,29 @@ public class Intake extends Mechanism {
 
 	//for now this is just a copy of the 2020 intake so config names are most likely wrong
 	public Intake() {
-		m_frontIntakeWheel = RobotProvider.instance.getMotor("Intake.frontWheel");
-		m_middleIntakeWheel = RobotProvider.instance.getMotor("Intake.topWheel");
+		m_frontIntakeWheel = RobotProvider.instance.getMotor("intake.frontWheel");
+		m_middleIntakeWheel = RobotProvider.instance.getMotor("intake.topWheel");
 		m_intakeArm1 = RobotProvider.instance.getSolenoid("Intake.intakeArm1");
 		m_intakeArm2 = RobotProvider.instance.getSolenoid("Intake.intakeArm2");
 		m_frontIntakeWheel.setInverted(true);
 	}
 
-	public void startIntake() {
+	public void IntakeIn() {
 		checkContextOwnership();
 
 		m_intakeArm1.set(true);
 		m_intakeArm2.set(false);
 		m_frontIntakeWheel.set(1.0);
 		m_middleIntakeWheel.set(1.0);
+	}
+
+	public void IntakeOut(){
+		checkContextOwnership();
+
+		m_intakeArm1.set(true);
+		m_intakeArm2.set(false);
+		m_frontIntakeWheel.set(-1.0);
+		m_middleIntakeWheel.set(-1.0);
 	}
 
 	public void stopIntake() {

--- a/src/main/java/com/team766/robot/mechanisms/Intake.java
+++ b/src/main/java/com/team766/robot/mechanisms/Intake.java
@@ -32,7 +32,7 @@ public class Intake extends Mechanism {
 		startArms();
 		topIntakeWheels.set(power);
 		bottomIntakeWheels.set(power);
-		conveyorBelt.set(power);
+		conveyorBelt.set(power*0.5);
 
 	}
 
@@ -87,7 +87,7 @@ public class Intake extends Mechanism {
 
 		topIntakeWheels.set(-power);
 		bottomIntakeWheels.set(-power);
-		conveyorBelt.set(-power);
+		conveyorBelt.set(-power*0.5);
 
 		startArms();
 	}

--- a/src/main/java/com/team766/robot/mechanisms/Intake.java
+++ b/src/main/java/com/team766/robot/mechanisms/Intake.java
@@ -10,7 +10,6 @@ public class Intake extends Mechanism {
 	private SolenoidController rightPiston;
 	private MotorController topBelt;
 	private MotorController bottomWheels;
-	private boolean beltGoing = false;
 	
 	public Intake() {
 		topBelt = RobotProvider.instance.getMotor("Intake.topWheels");
@@ -23,7 +22,6 @@ public class Intake extends Mechanism {
 
 	public void startIntake() {
 		checkContextOwnership();
-		//double power = ConfigFileReader.getInstance().getDouble("Intake.intakePower").get();
 		
 		startArms();
 		topBelt.set(1.0);
@@ -38,28 +36,6 @@ public class Intake extends Mechanism {
 		bottomWheels.set(0.0);
 		stopArms();
 	}
-	/*
-	* Intake code that would use color sensor 
-	* to automatically stop intake when piece reaches end of belt.
-	* Can  be manually stopped by pressing button again.
-	*
-	* checkContextOwnership();
-	* double power = ConfigFileReader.getInstance().getDouble("Intake.intakePower").get();
-    *
-	* if(beltGoing){
-	*	topBelt.set(0.0);
-	*   bottomWheels.set(0.0);
-	*	conveyorBelt.set(0.0);
-	*	stopArms();
-	* } else {
-	*	startArms();
-	*	topBelt.set(1.0);
-	*	bottomWheels.set(1.0);
-	*	conveyorBelt.set(1.0);
-	* }
-	* a different method will check if the sensor sees stuff
-	* if(sensor1.getStorage || sensor2.getStrorage) stop the motors and arms
-	*/
 
 	public void startArms(){
 		checkContextOwnership();
@@ -77,7 +53,6 @@ public class Intake extends Mechanism {
 
 	public void reverseIntake(){
 		checkContextOwnership();
-		//double power = ConfigFileReader.getInstance().getDouble("Intake.intakePower").get();
 
 		topBelt.set(-1.0);
 		bottomWheels.set(-1.0);

--- a/src/main/java/com/team766/robot/mechanisms/Intake.java
+++ b/src/main/java/com/team766/robot/mechanisms/Intake.java
@@ -1,44 +1,8 @@
 package com.team766.robot.mechanisms;
 
 import com.team766.framework.Mechanism;
-import com.team766.hal.MotorController;
 import com.team766.hal.RobotProvider;
-import com.team766.hal.SolenoidController;
-import com.team766.hal.wpilib.CANSparkMaxMotorController;
-import com.team766.hal.wpilib.Solenoid;
-
+import com.team766.hal.MotorController;
 public class Intake extends Mechanism {
 	
-	private MotorController bottomWheels;
-	private MotorController topBelt;
-	private SolenoidController leftPiston;
-	private SolenoidController rightPiston;
-
-	public Intake(){
-		bottomWheels = RobotProvider.instance.getMotor("intake.bottomWheels");
-		topBelt = RobotProvider.instance.getMotor("intake.topWheels");
-		leftPiston = RobotProvider.instance.getSolenoid("intake.leftPiston");
-		rightPiston = RobotProvider.instance.getSolenoid("intake.rightPiston");
-	}
-
-	public void intakeIn(){
-		bottomWheels.set(1);
-		topBelt.set(1);
-		leftPiston.set(true);
-		rightPiston.set(true);
-	}
-
-	public void intakeOut(){
-		bottomWheels.set(-1);
-		topBelt.set(-1);
-		leftPiston.set(true);
-		rightPiston.set(true);
-	}
-
-	public void intakeIdle(){
-		bottomWheels.set(0);
-		topBelt.set(0);
-		leftPiston.set(false);
-		rightPiston.set(false);
-	}
 }

--- a/src/main/java/com/team766/robot/mechanisms/Intake.java
+++ b/src/main/java/com/team766/robot/mechanisms/Intake.java
@@ -26,7 +26,7 @@ public class Intake extends Mechanism {
 	public void startIntake() {
 		checkContextOwnership();
 		
-		startArms();
+		pistonsOut();
 		topBelt.set(1.0);
 		bottomWheels.set(1.0);
 
@@ -37,17 +37,17 @@ public class Intake extends Mechanism {
 		
 		topBelt.set(0.0);
 		bottomWheels.set(0.0);
-		stopArms();
+		pistonsIn();
 	}
 
-	public void startArms(){
+	public void pistonsOut(){
 		checkContextOwnership();
 
 		leftPiston.set(true);
 		rightPiston.set(true);
 	}
 
-	public void stopArms(){
+	public void pistonsIn(){
 		checkContextOwnership();
 
 		leftPiston.set(false);
@@ -60,6 +60,6 @@ public class Intake extends Mechanism {
 		topBelt.set(-1.0);
 		bottomWheels.set(-1.0);
 
-		startArms();
+		pistonsIn();
 	}
 }

--- a/src/main/java/com/team766/robot/mechanisms/Intake.java
+++ b/src/main/java/com/team766/robot/mechanisms/Intake.java
@@ -4,12 +4,15 @@ import com.team766.framework.Mechanism;
 import com.team766.hal.MotorController;
 import com.team766.hal.RobotProvider;
 import com.team766.hal.SolenoidController;
+import com.team766.hal.wpilib.CANSparkMaxMotorController;
+import com.team766.hal.wpilib.Solenoid;
 
 public class Intake extends Mechanism {
+	
+	private MotorController bottomWheels;
+	private MotorController topBelt;
 	private SolenoidController leftPiston;
 	private SolenoidController rightPiston;
-	private MotorController topBelt;
-	private MotorController bottomWheels;
 	
 	public Intake() {
 		topBelt = RobotProvider.instance.getMotor("Intake.topWheels");

--- a/src/main/java/com/team766/robot/mechanisms/Intake.java
+++ b/src/main/java/com/team766/robot/mechanisms/Intake.java
@@ -20,8 +20,8 @@ public class Intake extends Mechanism {
 		bottomIntakeWheels = RobotProvider.instance.getMotor("Intake.bottomWheels");
 		conveyorBelt = RobotProvider.instance.getMotor("Intake.conveyorBelt");
 
-		intakeArm1 = RobotProvider.instance.getSolenoid("Intake.intakeArm1");
-		intakeArm2 = RobotProvider.instance.getSolenoid("Intake.intakeArm2");
+		intakeArm1 = RobotProvider.instance.getSolenoid("Intake.leftPiston");
+		intakeArm2 = RobotProvider.instance.getSolenoid("Intake.rightPiston");
 
 	}
 

--- a/src/main/java/com/team766/robot/mechanisms/Intake.java
+++ b/src/main/java/com/team766/robot/mechanisms/Intake.java
@@ -1,49 +1,94 @@
-package com.team766.robot.mechanisms;
+package com.team766.frc2022.mechanisms;
 
+import com.team766.config.ConfigFileReader;
 import com.team766.framework.Mechanism;
-import com.team766.hal.RobotProvider;
-import com.team766.hal.MotorController;
 import com.team766.hal.SolenoidController;
+import com.team766.hal.CANSpeedController;
+import com.team766.hal.RobotProvider;
+import com.team766.hal.wpilib.DigitalInput;
 
 public class Intake extends Mechanism {
-	private SolenoidController m_intakeArm1;
-	private SolenoidController m_intakeArm2;
-	private MotorController m_frontIntakeWheel;
-	private MotorController m_middleIntakeWheel;
-
-	//for now this is just a copy of the 2020 intake so config names are most likely wrong
+	private SolenoidController intakeArm1;
+	private SolenoidController intakeArm2;
+	private MotorController topIntakeWheels;
+	private MotorController bottomIntakeWheels;
+	private MotorController conveyorBelt;
+	private boolean beltGoing = false;
+	
 	public Intake() {
-		m_frontIntakeWheel = RobotProvider.instance.getMotor("intake.frontWheel");
-		m_middleIntakeWheel = RobotProvider.instance.getMotor("intake.topWheel");
-		m_intakeArm1 = RobotProvider.instance.getSolenoid("Intake.intakeArm1");
-		m_intakeArm2 = RobotProvider.instance.getSolenoid("Intake.intakeArm2");
-		m_frontIntakeWheel.setInverted(true);
+		topIntakeWheels = RobotProvider.instance.getMotor("Intake.topWheels");
+		bottomIntakeWheels = RobotProvider.instance.getMotor("Intake.bottomWheels");
+		conveyorBelt = RobotProvider.instance.getMotor("Intake.conveyorBelt");
+
+		intakeArm1 = RobotProvider.instance.getSolenoid("Intake.intakeArm1");
+		intakeArm2 = RobotProvider.instance.getSolenoid("Intake.intakeArm2");
+
 	}
 
-	public void IntakeIn() {
+	public void startIntake() {
 		checkContextOwnership();
+		double power = ConfigFileReader.getInstance().getDouble("Intake.intakePower").get();
+		
+		startArms();
+		topIntakeWheels.set(power);
+		bottomIntakeWheels.set(power);
+		conveyorBelt.set(power);
 
-		m_intakeArm1.set(true);
-		m_intakeArm2.set(false);
-		m_frontIntakeWheel.set(1.0);
-		m_middleIntakeWheel.set(1.0);
-	}
-
-	public void IntakeOut(){
-		checkContextOwnership();
-
-		m_intakeArm1.set(true);
-		m_intakeArm2.set(false);
-		m_frontIntakeWheel.set(-1.0);
-		m_middleIntakeWheel.set(-1.0);
 	}
 
 	public void stopIntake() {
 		checkContextOwnership();
+		
+		topIntakeWheels.set(0.0);
+		bottomIntakeWheels.set(0.0);
+		conveyorBelt.set(0.0);
+		stopArms();
+	}
+	/*
+	* Intake code that would use color sensor 
+	* to automatically stop intake when piece reaches end of belt.
+	* Can  be manually stopped by pressing button again.
+	*
+	* checkContextOwnership();
+	* double power = ConfigFileReader.getInstance().getDouble("Intake.intakePower").get();
+    *
+	* if(beltGoing){
+	*	topIntakeWheels.set(0.0);
+	*   bottomIntakeWheels.set(0.0);
+	*	conveyorBelt.set(0.0);
+	*	stopArms();
+	* } else {
+	*	startArms();
+	*	topIntakeWheels.set(power);
+	*	bottomIntakeWheels.set(power);
+	*	conveyorBelt.set(power);
+	* }
+	* a different method will check if the sensor sees stuff
+	* if(colorSensor.getStorage) stop the motors and arms
+	*/
 
-		m_middleIntakeWheel.set(0.0);
-		m_frontIntakeWheel.set(0.0);
-		m_intakeArm1.set(false);
-		m_intakeArm2.set(true);
+	public void startArms(){
+		checkContextOwnership();
+
+		intakeArm1.set(true);
+		intakeArm2.set(true);
+	}
+
+	public void stopArms(){
+		checkContextOwnership();
+
+		intakeArm1.set(false);
+		intakeArm2.set(false);
+	}
+
+	public void reverseIntake(){
+		checkContextOwnership();
+		double power = ConfigFileReader.getInstance().getDouble("Intake.intakePower").get();
+
+		topIntakeWheels.set(-power);
+		bottomIntakeWheels.set(-power);
+		conveyorBelt.set(-power);
+
+		startArms();
 	}
 }

--- a/src/main/java/com/team766/robot/mechanisms/Intake.java
+++ b/src/main/java/com/team766/robot/mechanisms/Intake.java
@@ -3,6 +3,38 @@ package com.team766.robot.mechanisms;
 import com.team766.framework.Mechanism;
 import com.team766.hal.RobotProvider;
 import com.team766.hal.MotorController;
+import com.team766.hal.SolenoidController;
+
 public class Intake extends Mechanism {
-	
+	private SolenoidController m_intakeArm1;
+	private SolenoidController m_intakeArm2;
+	private MotorController m_frontIntakeWheel;
+	private MotorController m_middleIntakeWheel;
+
+	//for now this is just a copy of the 2020 intake so config names are most likely wrong
+	public Intake() {
+		m_frontIntakeWheel = RobotProvider.instance.getMotor("Intake.frontWheel");
+		m_middleIntakeWheel = RobotProvider.instance.getMotor("Intake.topWheel");
+		m_intakeArm1 = RobotProvider.instance.getSolenoid("Intake.intakeArm1");
+		m_intakeArm2 = RobotProvider.instance.getSolenoid("Intake.intakeArm2");
+		m_frontIntakeWheel.setInverted(true);
+	}
+
+	public void startIntake() {
+		checkContextOwnership();
+
+		m_intakeArm1.set(true);
+		m_intakeArm2.set(false);
+		m_frontIntakeWheel.set(1.0);
+		m_middleIntakeWheel.set(1.0);
+	}
+
+	public void stopIntake() {
+		checkContextOwnership();
+
+		m_middleIntakeWheel.set(0.0);
+		m_frontIntakeWheel.set(0.0);
+		m_intakeArm1.set(false);
+		m_intakeArm2.set(true);
+	}
 }

--- a/src/main/java/com/team766/robot/mechanisms/Storage.java
+++ b/src/main/java/com/team766/robot/mechanisms/Storage.java
@@ -3,7 +3,6 @@ package com.team766.robot.mechanisms;
 import com.team766.framework.Mechanism;
 import com.team766.hal.MotorController;
 import com.team766.hal.RobotProvider;
-import com.team766.hal.SolenoidController;
 
 public class Storage extends Mechanism {
 	
@@ -14,14 +13,14 @@ public class Storage extends Mechanism {
 	}
 
 	public void beltIn(){
-		belt.set(1);
+		belt.set(0.5);
 	}
 
 	public void beltOut(){
-		belt.set(-1);
+		belt.set(-1.0);
 	}
 
 	public void beltIdle(){
-		belt.set(0);
+		belt.set(0.0);
 	}
 }

--- a/src/main/java/com/team766/robot/mechanisms/Storage.java
+++ b/src/main/java/com/team766/robot/mechanisms/Storage.java
@@ -4,7 +4,6 @@ import com.team766.framework.Mechanism;
 import com.team766.hal.MotorController;
 import com.team766.hal.RobotProvider;
 import com.team766.hal.SolenoidController;
-import com.team766.hal.wpilib.CANSparkMaxMotorController;
 
 public class Storage extends Mechanism {
 	

--- a/src/main/java/com/team766/robot/mechanisms/Storage.java
+++ b/src/main/java/com/team766/robot/mechanisms/Storage.java
@@ -8,19 +8,19 @@ public class Storage extends Mechanism {
 	
 	private MotorController belt;
 
-	public Storage(){
+	public Storage() {
 		belt = RobotProvider.instance.getMotor("belt");
 	}
 
-	public void beltIn(){
+	public void beltIn() {
 		belt.set(0.5);
 	}
 
-	public void beltOut(){
+	public void beltOut() {
 		belt.set(-1.0);
 	}
 
-	public void beltIdle(){
+	public void beltIdle() {
 		belt.set(0.0);
 	}
 }

--- a/src/main/java/com/team766/robot/procedures/IntakeIn.java
+++ b/src/main/java/com/team766/robot/procedures/IntakeIn.java
@@ -1,0 +1,14 @@
+package com.team766.robot.procedures;
+
+import com.team766.framework.Context;
+import com.team766.framework.Procedure;
+import com.team766.robot.Robot;
+
+public class IntakeIn extends Procedure{
+	public void run(Context context){
+		context.takeOwnership(Robot.intake);
+		context.takeOwnership(Robot.storage);
+		Robot.intake.startIntake();
+		Robot.storage.beltIn();
+	}
+}

--- a/src/main/java/com/team766/robot/procedures/IntakeOut.java
+++ b/src/main/java/com/team766/robot/procedures/IntakeOut.java
@@ -1,0 +1,14 @@
+package com.team766.robot.procedures;
+
+import com.team766.framework.Context;
+import com.team766.framework.Procedure;
+import com.team766.robot.Robot;
+
+public class IntakeOut extends Procedure{
+	public void run(Context context){
+		context.takeOwnership(Robot.intake);
+		context.takeOwnership(Robot.storage);
+		Robot.intake.reverseIntake();
+		Robot.storage.beltOut();
+	}
+}

--- a/src/main/java/com/team766/robot/procedures/IntakeStop.java
+++ b/src/main/java/com/team766/robot/procedures/IntakeStop.java
@@ -1,0 +1,14 @@
+package com.team766.robot.procedures;
+
+import com.team766.framework.Context;
+import com.team766.framework.Procedure;
+import com.team766.robot.Robot;
+
+public class IntakeStop extends Procedure{
+	public void run(Context context){
+		context.takeOwnership(Robot.intake);
+		context.takeOwnership(Robot.storage);
+		Robot.intake.startIntake();
+		Robot.storage.beltIdle();
+	}
+}


### PR DESCRIPTION
## Description

This PR would replace the current intake code. Includes finished Rev A intake/storage code (except for final button numbers) with documentation. All of the methods are the exact same as the current intake code. The only difference other than slightly different syntax and documentation is that the intake and outtake buttons must be held instead of pressed once to start and once to stop. 

## How Has This Been Tested?

The code is effectively the same as what we have previously tested on Rev A. The only thing not tested on Rev A are the new push and hold controls, which are very straightforward and have been tested in the simulator. Before using this code in a competition, we might want to change which buttons are used. 